### PR TITLE
Support OTA on Server + New Readers Page (#729)

### DIFF
--- a/client/src/pages/lab_management/audit_logs/AuditLogEntity.tsx
+++ b/client/src/pages/lab_management/audit_logs/AuditLogEntity.tsx
@@ -21,9 +21,9 @@ function getEntityUrl(entityType: string, id: string, makerspaceID: string) {
     case "conceal":
       return "#";
     case "access_device":
-      return `/makerspace/${makerspaceID}/readers`;
+      return `/makerspace/${makerspaceID}/readers#id-${id}`;
     case "machine":
-      return `/makerspace/${makerspaceID}/readers`;
+      return `/makerspace/${makerspaceID}/readers#id-${id}`;
     case "makerspace":
       return `/makerspace/${id}`;
     default:

--- a/client/src/pages/lab_management/manage_equipment/EquipmentInstanceCard.tsx
+++ b/client/src/pages/lab_management/manage_equipment/EquipmentInstanceCard.tsx
@@ -20,6 +20,7 @@ import ReportProblemIcon from '@mui/icons-material/ReportProblemSharp';
 import StarsIcon from '@mui/icons-material/Stars';
 import PendingIcon from '@mui/icons-material/Pending';
 import WifiOffIcon from '@mui/icons-material/WifiOff';
+import AuditLogEntity from "../audit_logs/AuditLogEntity";
 
 interface EquipmentInstanceCardProps {
     instance: EquipmentInstance;
@@ -186,7 +187,7 @@ export default function EquipmentInstanceCard(props: EquipmentInstanceCardProps)
                         />
                         : <Typography variant="body1" align="center">{
                             reader ?
-                                <span>Paired with: <Link href="/app/admin/readers">{reader.name}</Link></span>
+                                <span>Paired with: <AuditLogEntity entityCode={`access_device:${reader.id}:${reader.name}`}/></span>
                                 : <Alert severity="warning" variant="filled">No Reader Paired</Alert>}
                         </Typography>
                 }

--- a/client/src/pages/lab_management/readers/ReaderCard.tsx
+++ b/client/src/pages/lab_management/readers/ReaderCard.tsx
@@ -1,91 +1,233 @@
 import {
-  Box,
+  Autocomplete,
   Button,
   Card,
   CardContent,
-  Checkbox,
-  Divider,
+  CircularProgress,
+  IconButton,
   Link,
-  MenuItem,
-  Select,
+  SpeedDial,
+  SpeedDialAction,
+  SpeedDialIcon,
   Stack,
+  TextField,
+  Tooltip,
   Typography,
+  useTheme,
 } from "@mui/material";
+import SendIcon from '@mui/icons-material/Send';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { GET_CORRESPONDING_MACHINE_BY_READER_ID_OR_MACHINE_ID } from "../../../queries/equipmentQueries";
 import RequestWrapper from "../../../common/RequestWrapper";
-import AuditLogEntity from "../audit_logs/AuditLogEntity";
 import { useQuery, useMutation } from "@apollo/client";
 import TimeAgo from 'react-timeago'
-import { DELETE_READER, GET_READERS, IDENTIFY_READER, Reader, SET_READER_STATE } from "../../../queries/readersQueries";
+import { DELETE_READER, GET_AVAILABLE_FIRMWARE_VERSIONS, GET_MAKERSPACE_FOR_WELCOME_READER, GET_READERS, IDENTIFY_READER, Reader, REQUEST_OTA_UPDATE, SET_READER_STATE } from "../../../queries/readersQueries";
+import LanIcon from '@mui/icons-material/Lan';
+import SaveIcon from '@mui/icons-material/Save';
+import LockIcon from '@mui/icons-material/Lock';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import HourglassFullIcon from '@mui/icons-material/HourglassFull';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import ReportProblemIcon from '@mui/icons-material/ReportProblemSharp';
+import StarsIcon from '@mui/icons-material/Stars';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import { useState } from "react";
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import CloseIcon from '@mui/icons-material/Close';
 
 interface ReaderCardProps {
   reader: Reader
   makerspaceID: string,
+  searchQuery: string,
 }
 
 
 
-const styles = {
-  errorText: {
-    color: "red",
-    fontWeight: "bold"
-  },
-  errorCard: {
-    border: "3px solid red"
-  },
-  notifCard: {
-    border: "3px solid blue"
-  }
-};
-
-const nullUser = {
-  id: null,
-  firstName: null,
-  lastname: ""
+function shouldShowBasedOnSearchTerm(search: string, reader: Reader, pairedThing: string): boolean{
+  const lowerSearch = search.toLocaleLowerCase();
+  const lowerReader = reader.name.toLocaleLowerCase();
+  const lowerPaired = pairedThing.toLocaleLowerCase();
+  return lowerReader.includes(lowerSearch) || lowerPaired.includes(lowerSearch)
 }
 
-export default function ReaderCard({ reader, makerspaceID }: ReaderCardProps) {
-  const readerUser = reader.user ?? nullUser
-
-  const stateContent = reader.state === "Active" ? (
-    <p>Current User: <AuditLogEntity entityCode={`user:${readerUser.id}:${readerUser.firstName} ${readerUser.lastName}`}></AuditLogEntity><br></br>Session Length: {reader.recentSessionLength} sec</p>
-  ) : (
-    <p>Last User: {readerUser.id != null ? (<AuditLogEntity entityCode={`user:${readerUser.id}:${readerUser.firstName} ${readerUser.lastName}`}></AuditLogEntity>) : "NULL"}<br></br>Session Length: {reader.recentSessionLength} sec</p>
-  );
+export default function ReaderCard({ reader, makerspaceID, searchQuery }: ReaderCardProps) {
+  const theme = useTheme();
 
   const machineResult = useQuery(GET_CORRESPONDING_MACHINE_BY_READER_ID_OR_MACHINE_ID, {
     variables: { readerid: reader.id, id: reader.machineID }
   });
+  const makerspaceResult = useQuery(GET_MAKERSPACE_FOR_WELCOME_READER, {
+    variables: { readerId: reader.id },
+  });
   const machine = machineResult?.data?.correspondingEquipment;
+  const makerspace = makerspaceResult?.data?.makerspaceForWelcomeReader
+
+  const pairedThing = (machine ? machine.name : makerspace ? makerspace.name : "");
+  const shouldShow = shouldShowBasedOnSearchTerm(searchQuery, reader, pairedThing);
 
   const now = new Date();
   const lastTimeDifference = now.getTime() - (new Date(reader.lastStatusTime).getTime());
+  const isOffline = lastTimeDifference > 30 * 1000;
 
   const [setReaderState] = useMutation(SET_READER_STATE);
-  const handleChange = (event: any) => {
-    // If the value was the informational one, ignore it
-    if (event.target.value === "State") {
-      return;
-    }
-    setReaderState({ variables: { id: reader.id, state: event.target.value } });
-  };
-
   const [doIdentify] = useMutation(IDENTIFY_READER)
-  function handleIdentifyChecked(checked: boolean) {
-    doIdentify({ variables: { "id": reader.id, doIdentify: checked } })
-  }
+  const [identifying, setIdentifying] = useState<boolean>(false);
+  const handleChange = (state: string) => {
+    if (state === "Identify") {
+      setIdentifying(!identifying);
+      doIdentify({ variables: { "id": reader.id, doIdentify: identifying } })
+    } else {
+      setReaderState({ variables: { id: reader.id, state: state } });
+    }
+  };
 
   const [deleteReader] = useMutation(DELETE_READER, { refetchQueries: [{ query: GET_READERS }] })
 
-  return (
+  const [dialOpen, setDialOpen] = useState(false);
+  
+
+
+  function machineOrMakerspace() {
+    if (machine) {
+      const l = <Link href={"/app/admin/equipment/" + (machine.archived ? "/archived" : "") + (machine.id)}> {machine.name}</Link>
+      return <span><b>Machine: </b> {l} </span>
+    } else if (makerspace) {
+      const l = <Link href={`/app/makerspace/${makerspace.id}`}>{makerspace.name}</Link>
+      return <span><b>Welcome For: </b> {l} </span>
+    } else {
+      return <b>Not Paired with Machine or Makerspace</b>
+    }
+  }
+
+  function lastStatusTime() {
+    return <span style={{ fontWeight: isOffline ? 'bold' : 'regular', color: isOffline ? 'red' : 'inherit' }}>
+      <TimeAgo date={reader.lastStatusTime} component={"span"} />
+    </span>
+  }
+
+  function stateAndTemp() {
+
+    return <Card variant="outlined"><CardContent>
+      <Stack direction={"row"}>
+        <Stack direction={"column"} justifyContent={"center"} width={"70%"} >
+          State
+          <Typography textAlign={"center"} variant={"h4"}>{reader.state}</Typography>
+        </Stack>
+
+        <Stack direction={"column"} justifyContent={"center"} width={"30%"} >
+          <Typography textAlign={"right"}>Temp (&#176;C)</Typography>
+          <Typography textAlign={"center"} variant={"h4"}>{Math.round(reader.temp)}</Typography>
+        </Stack>
+      </Stack>
+    </CardContent></Card>;
+  }
+
+
+  function ShowVersions() {
+    const labels = true ?
+      ["Current SW", "Pending SW", "HW Version"]
+      : ["BEVer", "FEVer", "HWVer"];
+    const values = [reader.BEVer, reader.FEVer, reader.HWVer];
+
+
+    return <Stack direction={"row"} justifyContent={"center"} spacing={1} paddingTop={"3px"} paddingBottom={"3px"}>
+      <Stack direction={"column"}>
+        {labels.map(l => <div><b>{l}: </b></div>)}
+      </Stack>
+
+      <Stack direction={"column"}>
+        {values.map(v => <div>{(v !== '') ? v : "N/A"}</div>)}
+      </Stack>
+    </Stack>
+  }
+
+  const firmwareVersions = useQuery(GET_AVAILABLE_FIRMWARE_VERSIONS);
+
+  function otaOptions(): string[] {
+    var options = [];
+    options.push("stable");
+    options.push("no-ota");
+    if (firmwareVersions.data) {
+      options.push(...firmwareVersions.data.availableFirmwareVersions)
+    }
+    return options;
+  }
+
+
+  const [otaSelection, setOtaSelection] = useState<string>(reader.targetFirmwareVersion ?? "")
+  const [requestOTA] = useMutation(REQUEST_OTA_UPDATE, { refetchQueries: [{ query: GET_READERS }] });
+
+  function saveOTA(sendNow: boolean) {
+    if (otaSelection === "no-ota") {
+      sendNow = false; // this isnt a real tag so dont tell it to update rn
+    }
+    requestOTA({ variables: { ids: [reader.id], otaTag: otaSelection, updateNow: sendNow } });
+  }
+
+  function OTAControl() {
+
+    return <Stack direction={"row"}>
+      {firmwareVersions.loading ? <CircularProgress color="primary" size={"1em"} /> :
+        <Autocomplete
+          renderInput={(params: any) => <TextField {...params} label="OTA Target Version" />}
+          size="small"
+          options={otaOptions()}
+          disableClearable
+          onChange={(_, val) => setOtaSelection(val)}
+          value={otaSelection}
+          fullWidth
+          loading={firmwareVersions.loading}
+        />
+
+      }
+      <Tooltip title="Save">
+        <IconButton sx={{ color: theme.palette.info.main }} onClick={() => saveOTA(false)}><SaveIcon /></IconButton>
+      </Tooltip>
+      <Tooltip title="Save and Update">
+        <IconButton sx={{ color: theme.palette.success.main }} onClick={() => saveOTA(true)}><SendIcon /></IconButton>
+      </Tooltip>
+    </Stack>
+
+  }
+
+  function SendStateSpeedDial() {
+    return <SpeedDial
+      ariaLabel="Send State Speeddial"
+      color="secondary"
+      icon={<SpeedDialIcon icon={<MoreHorizIcon />} openIcon={<CloseIcon />} />}
+      open={dialOpen}
+      onClick={() => setDialOpen(!dialOpen)}
+      sx={{ justifySelf: "right", position: "relative", paddingRight: "5px" }}
+    >
+      {[
+        { name: "Idle", icon: <HourglassFullIcon color="warning" /> },
+        { name: "Unlocked", icon: <LockOpenIcon color="success" /> },
+        { name: "AlwaysOn", icon: <StarsIcon color="success" /> },
+        { name: "Lockout", icon: <LockIcon color="error" /> },
+        { name: "Fault", icon: <ReportProblemIcon color="error" /> },
+        { name: "Restart", icon: <RestartAltIcon color="info" /> },
+        { name: "Identify", icon: <FingerprintIcon color="info" /> }
+      ].map((d, i) => {
+        return <SpeedDialAction
+          key={i}
+          icon={d.icon}
+          slotProps={{ tooltip: { title: d.name, open: true } }}
+          sx={{ position: "absolute", bottom: `${(i + 1) * 50 + 20}px` }}
+          onClick={() => handleChange(d.name)}
+        ></SpeedDialAction>
+      })}
+
+    </SpeedDial>
+  }
+
+  return shouldShow ? (
     <RequestWrapper
       loading={machineResult.loading}
       error={machineResult.error}
     >
-      <Card sx={{ width: 350, minHeight: 600, border: (reader.lastStatusReason == "Error" || reader.lastStatusReason == "Temperature" ? styles.errorCard : reader.helpRequested ? styles.notifCard : "") }}>
-        <CardContent>
-          <Stack direction={"row"} justifyContent={"space-between"}  paddingBottom={"5px"}>
+      <Card id={`id-${reader.id}`} sx={{ width: 350, margin: "10px", border: '2px solid ' + ((reader.state === "Fault") ? theme.palette.error.main : "#ffffff00") }} >
+        <CardContent id={reader.name}>
+          <Stack direction={"row"} justifyContent={"space-between"} paddingBottom={"5px"}>
             <Typography variant="h5">{reader.name}</Typography>
 
             <Button variant="contained" color="error" size="small" onClick={() => {
@@ -95,125 +237,36 @@ export default function ReaderCard({ reader, makerspaceID }: ReaderCardProps) {
             }}><DeleteIcon />
             </Button>
           </Stack>
-          <Typography variant="subtitle2" textOverflow={"scroll"}>
-            <b>SN:</b> {reader.SN}
-          </Typography>
 
 
-          <Typography
-            variant="body2"
-            component="div"
-            sx={{ lineHeight: 1, mb: 1 }}
-            noWrap
-          >
-            <b>Reader ID: </b>{reader.id}
-            <br></br>
-            <b>Machine: </b>
-            {
-              (machine) ?
-                <Link href={"/app/admin/equipment/" + (machine.archived ? "/archived" : "") + (machine.id)}> {machine.name}</Link>
-                : "Not paired"
-            }
-
-            <br></br>
-          </Typography>
-          <Card variant="outlined">
-            <CardContent>
-              <Typography
-                variant="h6"
-                component="div"
-                sx={{ lineHeight: 1, mb: 1 }}
-                noWrap
-              >
-                Temp (&#176;C)
-              </Typography>
-              <Typography
-                variant="h3"
-                component="div"
-                sx={{ lineHeight: 1, mb: 1 }}
-                align="center"
-                noWrap
-              >
-                {reader.temp}
-              </Typography>
-            </CardContent>
-          </Card>
-          <Card variant="outlined">
-            <CardContent>
-              <Typography
-                variant="h6"
-                component="div"
-                sx={{ lineHeight: 1, mb: 1 }}
-                noWrap
-              >
-                State
-              </Typography>
-              <Typography
-                variant="h4"
-                component="div"
-                sx={{ lineHeight: 1, mb: 1 }}
-                noWrap
-                align="center"
-              >
-                {reader.state == null ? "NULL" : reader.state}
-              </Typography>
-            </CardContent>
-          </Card>
-          <br />
-          <Stack>
-            <Typography
-              variant="body2"
-              component="div"
-              sx={{ lineHeight: 1, mb: 1 }}
-              noWrap
-            >
-              {/* @ts-ignore */}
-              <b>Last Status:</b> <span style={{ fontWeight: lastTimeDifference > 60000 ? 'bold' : 'regular', color: lastTimeDifference > 60000 ? 'red' : 'inherit' }}><TimeAgo date={reader.lastStatusTime} locale="en-US" /></span>
-            </Typography>
-            <Typography
-              variant="body2"
-              component="div"
-              sx={{ lineHeight: 1, mb: 1 }}
-              noWrap
-            >
-              <b>Reason:</b> <span style={(reader.lastStatusReason == "Error" || reader.lastStatusReason == "Temperature") ? styles.errorText : {}}>{reader.lastStatusReason}</span><br></br>
-            </Typography>
+          <Stack direction={"column"} fontSize={".9em"} paddingBottom={"2px"}>
+            <span><b>SN:</b> {reader.SN}</span>
+            <span><b>Reader ID: </b>{reader.id}</span>
+            {machineOrMakerspace()}
+            <span>Last Online: {lastStatusTime()}</span>
           </Stack>
-          <Typography
-            variant="body2"
-            component="div"
-            sx={{ lineHeight: 1, mb: 1 }}
-            noWrap
-          >
-            {stateContent}
-            <Stack direction="row" justifyContent={"space-between"} alignItems={"center"}>
-              Identify Reader
-              <Checkbox onChange={(e, checked) => handleIdentifyChecked(checked)}></Checkbox>
-            </Stack>
 
-          </Typography>
-          <Stack spacing={1} alignItems="center">
-            <Select defaultValue={"State"} onChange={handleChange} fullWidth>
-              <MenuItem value="State">State</MenuItem>
-              <MenuItem value="Idle">Idle</MenuItem>
-              <MenuItem value="Unlocked">Unlocked</MenuItem>
-              <MenuItem value="AlwaysOn">Always On</MenuItem>
-              <MenuItem value="Lockout">Lockout</MenuItem>
-              <MenuItem value="Fault">Fault</MenuItem>
-              <MenuItem value="Startup">Startup</MenuItem>
-              <MenuItem value="Welcoming">Welcoming</MenuItem>
-              <MenuItem value="Restart">Restart</MenuItem>
-            </Select>
-            <Box>
-              <Stack direction={"row"} spacing={2}>
-                <Typography variant="body2"><b>BEVer:</b> {reader.BEVer ?? "NULL"}</Typography>
-                <Typography variant="body2"><b>FEVer:</b> {reader.FEVer ?? "NULL"}</Typography>
-                <Typography variant="body2"><b>HWVer:</b> {reader.HWVer ?? "NULL"}</Typography>
-              </Stack>
-            </Box>
+          {stateAndTemp()}
+
+          {ShowVersions()}
+
+          {OTAControl()}
+
+
+          <Stack direction={"row"} justifyContent={"space-between"} justifyItems={"center"} alignItems={"flex-end"}>
+            <Button
+              variant="contained"
+              color="secondary"
+              endIcon={<LanIcon />}
+              onClick={() => alert("Uh, this button doesnt do anything?.....")}
+            >
+              Manage Switch(es)</Button>
+
+            {SendStateSpeedDial()}
           </Stack>
+
         </CardContent>
       </Card>
     </RequestWrapper>
-  );
+  ) : false;
 }

--- a/client/src/pages/lab_management/readers/ReadersPage.tsx
+++ b/client/src/pages/lab_management/readers/ReadersPage.tsx
@@ -1,30 +1,37 @@
 import { useQuery } from "@apollo/client";
 import { GET_READERS, Reader } from "../../../queries/readersQueries";
 import { Box, Button, Grid, Link, Stack } from "@mui/material";
-import Page from "../../Page";
 import SearchBar from "../../../common/SearchBar";
 import { useNavigate, useParams } from "react-router-dom";
 import RequestWrapper from "../../../common/RequestWrapper";
-import { useState } from "react";
+import { isValidElement, useEffect, useState } from "react";
 import ReaderCard from "./ReaderCard";
-import AdminPage from "../../AdminPage";
 import { useCurrentUser } from "../../../common/CurrentUserProvider";
 import AddIcon from '@mui/icons-material/Add';
-import AnalyticsIcon from '@mui/icons-material/Analytics';
 
 export default function ReadersPage() {
-  const { makerspaceID } = useParams<{makerspaceID: string}>();
+  const { makerspaceID } = useParams<{ makerspaceID: string }>();
 
-  const getReadersResult = useQuery(GET_READERS, {pollInterval: 2000});
+  const getReadersResult = useQuery(GET_READERS, { pollInterval: 2000 });
   const user = useCurrentUser();
   const navigate = useNavigate();
 
   const [searchText, setSearchText] = useState("");
 
+  useEffect(() => {
+    const hash = window.location.hash.slice(1); // Remove the '#' character from the hash
+    if (hash) {
+      const element = document.getElementById(hash);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, []);
+
   return (
     <Box padding="20px">
       <title>Readers | Make @ RIT</title>
-      <Stack direction="row" spacing={2}>
+      <Stack direction="row" spacing={2} marginBottom={"10px"}>
         <SearchBar
           placeholder="Search access devices"
           value={searchText}
@@ -39,18 +46,18 @@ export default function ReadersPage() {
         loading={getReadersResult.loading}
         error={getReadersResult.error}
       >
-        <Grid container spacing={3} mt={2}>
-          {getReadersResult.data?.readers?.filter((m: Reader) =>
-            m.name
-              .toLocaleLowerCase()
-              .includes(searchText.toLocaleLowerCase())
-          ).map((reader: Reader) => (
-            <Grid key={reader.id} alignItems="stretch">
-              <ReaderCard 
-                reader={reader}
-                makerspaceID={makerspaceID ?? "0"}/>
+        <Grid container >
+          {getReadersResult.data?.readers?.map((reader: Reader) => ({
+            reader: reader,
+            card: <ReaderCard
+              reader={reader}
+              makerspaceID={makerspaceID ?? "0"}
+              searchQuery={searchText} />,
+          })).filter((o: { reader: Reader, card: any }) => {return isValidElement(o.card)}).map((o: { reader: Reader, card: any }) => {
+            return <Grid key={o.reader.id} alignItems="stretch">
+              {o.card}
             </Grid>
-          ))}
+          })}
         </Grid>
       </RequestWrapper>
     </Box>

--- a/client/src/pages/makerspace_page/ManageWelcomeReadersCard.tsx
+++ b/client/src/pages/makerspace_page/ManageWelcomeReadersCard.tsx
@@ -6,6 +6,7 @@ import { Box, Stack } from "@mui/system";
 import { Alert, Autocomplete, Button, Card, CardContent, IconButton, TextField, Tooltip, Typography } from "@mui/material";
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import AddLinkIcon from '@mui/icons-material/AddLink';
+import AuditLogEntity from "../lab_management/audit_logs/AuditLogEntity";
 
 
 export default function ManageWelcomReadersCard({ makerspaceId }: { makerspaceId: number }) {
@@ -54,7 +55,7 @@ export default function ManageWelcomReadersCard({ makerspaceId }: { makerspaceId
                                     <CardContent>
                                         <Stack direction={"row"} spacing={1} sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
                                             <Typography variant="h6" component="div">
-                                                {reader.name}
+                                                <AuditLogEntity entityCode={`access_device:${reader.id}:${reader.name}`} />
                                             </Typography>
                                             <Stack direction={"row"} alignItems={"center"}>
                                                 <Typography variant="body2" component="div">

--- a/client/src/queries/readersQueries.ts
+++ b/client/src/queries/readersQueries.ts
@@ -19,6 +19,7 @@ export interface Reader {
   HWVer: string,
   SN: string,
   sessionStartTime: number,
+  targetFirmwareVersion?: string,
 }
 
 export const GET_READERS = gql`
@@ -46,6 +47,9 @@ export const GET_READERS = gql`
       HWVer
       sessionStartTime
       SN
+      readerKeyCycle
+      pairTime
+      targetFirmwareVersion
     }
   }
 `;
@@ -74,6 +78,9 @@ export const GET_READER_BY_ID = gql`
       HWVer
       sessionStartTime
       SN
+      readerKeyCycle
+      pairTime
+      targetFirmwareVersion
     }
   }
 `;
@@ -132,9 +139,49 @@ export const GET_UNPAIRED_READERS = gql`
       HWVer
       sessionStartTime
       SN
+      readerKeyCycle
+      pairTime
+      targetFirmwareVersion
     }
   }
 `
+
+export const GET_MAKERSPACE_FOR_WELCOME_READER = gql`
+query Query($readerId: ID) {
+  makerspaceForWelcomeReader(readerId: $readerId){
+      id
+      name
+      imageUrl
+      rooms {
+        id
+        name
+        equipment {
+          id
+          name
+          imageUrl
+          sopUrl
+          trainingModules {
+            id
+            name
+          }
+          numAvailable
+          numInUse
+          byReservationOnly
+          notes
+          archived
+        }
+        trainingModules {
+          id
+          name
+        }
+      }
+      trainingModules {
+        id
+        name
+      }
+  }
+}
+`;
 
 export const GET_WELCOME_READERS_FOR_MAKERSPACE = gql`
 query GetWelcomeReadersForMakerspace($makerspaceId: ID!) {
@@ -163,6 +210,7 @@ query GetWelcomeReadersForMakerspace($makerspaceId: ID!) {
     SN
     readerKeyCycle
     pairTime
+    targetFirmwareVersion
   }
 }
 `;
@@ -253,5 +301,18 @@ export const IDENTIFY_READER = gql`
 export const SET_READER_STATE = gql`
   mutation SetReaderState($id: ID!, $state: String) {
     setState(id: $id, state: $state)
+  }
+`;
+
+
+export const GET_AVAILABLE_FIRMWARE_VERSIONS = gql`
+  query Query {
+    availableFirmwareVersions
+  }
+`;
+
+export const REQUEST_OTA_UPDATE = gql`
+  mutation SetOTAVersion($ids: [ID!]!, $otaTag: String!, $updateNow: Boolean!) {
+    setOTAVersion(ids: $ids, otaTag: $otaTag, updateNow: $updateNow)
   }
 `;

--- a/server/src/db/migrations/20250722182257_firmware_tracks.ts
+++ b/server/src/db/migrations/20250722182257_firmware_tracks.ts
@@ -1,0 +1,25 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    const exists = await knex.schema.hasColumn("Readers", "targetFirmwareVersion");
+    if (exists) {
+        return;
+    }
+    await knex.schema.alterTable("Readers", (t) => {
+        t.string("targetFirmwareVersion").nullable()
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    const exists = await knex.schema.hasColumn("Readers", "targetFirmwareVersion");
+    if (!exists) {
+        return;
+    }
+
+    await knex.schema.alterTable("Readers", (t) => {
+        t.dropColumn("targetFirmwareVersion");
+    });
+}
+

--- a/server/src/db/tables.ts
+++ b/server/src/db/tables.ts
@@ -259,6 +259,7 @@ export interface ReaderRow {
   SN?: string;
   readerKeyCycle: number;
   pairTime?: Date
+  targetFirmwareVersion?: string
 }
 
 export interface MakerspaceWelcomeReaderRow{

--- a/server/src/repositories/Readers/ReaderRepository.ts
+++ b/server/src/repositories/Readers/ReaderRepository.ts
@@ -53,7 +53,13 @@ export async function getReaderByMachineID(
  * Fetch all card readers
  */
 export async function getReaders(): Promise<ReaderRow[]> {
-    return await knex("Readers").select("*").orderBy("helpRequested", "desc").orderBy("id", "asc"); //Order them to prevent random ordering everytime the client polls, also prioritize help
+    //Order them to prevent random ordering everytime the client polls, also prioritize help
+    return await knex("Readers")
+        .select("*", knex.raw("case when state = 'Fault' then 0 else 1 end as \"faultOrder\""))
+        .orderBy("helpRequested", "desc")
+        .orderBy("faultOrder", "asc")
+        .orderBy("id", "asc")
+        ; 
 }
 
 /**
@@ -313,6 +319,15 @@ export async function getMakerspaceOfWelcomeReader(readerID: number): Promise<Zo
  */
 export async function getWelcomeReadersForMakerspace(makerspaceId: number): Promise<ReaderRow[]>{
     return await knex("MakerspaceWelcomeReaders").where({makerspaceID: makerspaceId}).leftJoin("Readers", "Readers.id", "MakerspaceWelcomeReaders.readerID").select("Readers.*");
+}
+
+/**
+ * Set the target firmware version for some readers
+ * @param ids the list of readers to set for
+ * @param version the firmware tag to set
+ */
+export async function setOTAVersions(ids: number[], version: string){
+    await knex("Readers").update("targetFirmwareVersion", version).whereIn("id", ids)
 }
 
 const ReaderCertCAId = 34;

--- a/server/src/resolvers/readersResolver.ts
+++ b/server/src/resolvers/readersResolver.ts
@@ -101,27 +101,33 @@ const ReadersResolver = {
       isStaff(async () => {
         return await ReaderRepo.getUnpairedReaders();
       }),
-      
-      /**
-       * 
-       * @param _args the id of the makerspace to query upon
-       * @returns a list of welcome readers paired to that makerspace
-       */
-      welcomeReadersForMakerspace: async (
-        _parent: any,
-        _args: {makerspaceId: number},
-        { isStaff }: ApolloContext) =>
-        isStaff(async () => {
-          return await ReaderRepo.getWelcomeReadersForMakerspace(_args.makerspaceId);
-        }),
-      
 
     /**
-   * Fetch Reader by ID
-   * @argument id ID of Reader
-   * @returns Reader
-   * @throws GraphQLError if not MENTOR or STAFF or is on hold
-   */
+     * 
+     * @param _args the id of the makerspace to query upon
+     * @returns a list of welcome readers paired to that makerspace
+     */
+    welcomeReadersForMakerspace: async (
+      _parent: any,
+      _args: { makerspaceId: number },
+      { isStaff }: ApolloContext) =>
+      isStaff(async () => {
+        return await ReaderRepo.getWelcomeReadersForMakerspace(_args.makerspaceId);
+      }),
+    makerspaceForWelcomeReader: async (
+      _parent: any,
+      args: { readerId: number },
+      { isStaff }: ApolloContext) =>
+      isStaff(async () => {
+        return await ReaderRepo.getMakerspaceOfWelcomeReader(Number(args.readerId));
+      }),
+
+    /**
+    * Fetch Reader by ID
+    * @argument id ID of Reader
+    * @returns Reader
+    * @throws GraphQLError if not MENTOR or STAFF or is on hold
+    */
     reader: async (
       _parent: any,
       args: { id: string },
@@ -145,6 +151,16 @@ const ReadersResolver = {
       isStaff(async () => {
         return await ReaderRepo.getReaderLogs(args);
       }),
+
+
+    availableFirmwareVersions: async (
+      _parent: any,
+      args: {},
+      { isStaff }: ApolloContext) =>
+      isStaff(async () => {
+        return ShlugControl.getAvailableFirmwareTags();
+      }),
+
   },
 
   Mutation: {
@@ -227,23 +243,23 @@ const ReadersResolver = {
     ) =>
       isStaffFor(args.makerspaceID, async (user) => {
         const success = await ReaderRepo.pairReaderAsMakerspaceWelcomer(args.readerID, args.makerspaceID);
-        if (success){
+        if (success) {
           ShlugControl.sendState(user, Number(args.readerID), "Welcoming");
         }
         return success;
       }),
-      
-      unpairAsWelcomeReader: async (
-        _parent: any,
-        args: { readerID: number, makerspaceID: number },
-        { isStaffFor }: ApolloContext
-      ) =>
-        isStaffFor(args.makerspaceID, async (user) => {
-          ShlugControl.sendState(user, Number(args.readerID), "Idle");          
-          return ReaderRepo.unpairReaderAsMakerspaceWelcomer(args.readerID, args.makerspaceID);
-        }),
-      
-  
+
+    unpairAsWelcomeReader: async (
+      _parent: any,
+      args: { readerID: number, makerspaceID: number },
+      { isStaffFor }: ApolloContext
+    ) =>
+      isStaffFor(args.makerspaceID, async (user) => {
+        ShlugControl.sendState(user, Number(args.readerID), "Idle");
+        return ReaderRepo.unpairReaderAsMakerspaceWelcomer(args.readerID, args.makerspaceID);
+      }),
+
+
     /**
      * Update the name of a Reader
      * @argument id of Reader to modify
@@ -295,6 +311,17 @@ const ReadersResolver = {
           return false;
         }
       }),
+    setOTAVersion: async (
+      _parent: any,
+      args: { ids: string[], otaTag: string, updateNow: boolean },
+      { isStaff }: ApolloContext
+    ) =>
+      isStaff(async (executingUser: any) => {
+        ReaderRepo.setOTAVersions(args.ids.map(Number), args.otaTag);
+        if (args.updateNow) {
+          return ShlugControl.requestOTA(executingUser, args.ids.map(Number), args.otaTag);
+        }
+      })
 
   }
 };

--- a/server/src/schemas/readersSchema.ts
+++ b/server/src/schemas/readersSchema.ts
@@ -27,6 +27,7 @@ export const ReaderTypeDefs = gql`
     SN: String
     readerKeyCycle: Int
     pairTime: DateTime
+    targetFirmwareVersion: String
   }
   type ReaderLog{
     id: ID!
@@ -46,8 +47,10 @@ export const ReaderTypeDefs = gql`
     readers: [Reader]
     unpairedReaders: [Reader]
     welcomeReadersForMakerspace(makerspaceId: ID!): [Reader]
+    makerspaceForWelcomeReader(readerId: ID): Zone
     reader(id: ID!): Reader
     readerLogs(makerspaceID: ID, from: DateTime, to: DateTime, pageOffset: Int, pageLimit: Int): [ReaderLog]
+    availableFirmwareVersions: [String]
   }
 
   extend type Mutation {
@@ -84,6 +87,7 @@ export const ReaderTypeDefs = gql`
 
     setName(id: ID!, name: String): Reader
     setState(id: ID!, state: String): String
+    setOTAVersion(ids: [ID!]!, otaTag: String!, updateNow: Boolean!): JSON
     identifyReader(id: ID!, doIdentify: Boolean): Boolean
     }
 `;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@ import express from "express";
 import expressWs from 'express-ws';
 import { ApolloServer } from "@apollo/server";
 import { expressMiddleware } from "@apollo/server/express4";
-import { createServer } from "http";
+import { createServer, request } from "http";
 import compression from "compression";
 import cors from "cors";
 import { schema } from "./schema.js";
@@ -22,7 +22,7 @@ import { createLog, createLogWithArray } from "./repositories/AuditLogs/AuditLog
 import { getEquipmentByID, getMissingTrainingModules, hasAccessByID } from "./repositories/Equipment/EquipmentRepository.js";
 import { Room } from "./models/rooms/room.js";
 import { Privilege } from "./schemas/usersSchema.js";
-import { createReader, getReaderByID, getReaderByName, getReaderCertCA, toggleHelpRequested, updateReaderStatus } from "./repositories/Readers/ReaderRepository.js";
+import { createReader, getReaderByID, getReaderByName, getReaderBySN, getReaderCertCA, toggleHelpRequested, updateReaderStatus } from "./repositories/Readers/ReaderRepository.js";
 import { isApproved } from "./repositories/Equipment/AccessChecksRepository.js";
 import morgan from "morgan"; //Log provider
 import bodyParser from "body-parser"; //JSON request body parser
@@ -31,7 +31,7 @@ import { getHoursByZone, WeekDays } from "./repositories/Zones/ZoneHoursReposito
 import { createEquipmentSession, pruneNullLengthEquipmentSessions, setLatestEquipmentSessionLength } from "./repositories/Equipment/EquipmentSessionsRepository.js";
 import { setDataPointValue } from "./repositories/DataPoints/DataPointsRepository.js";
 import { ReaderRow } from "./db/tables.js";
-import { authenticateReader, ws_acs_api } from "./wsapi.js"
+import { authenticateReader, ws_acs_api, wsApiLog } from "./wsapi.js"
 import { addItemAmount, getItemById, getItems, getItemsWhereStaff, getItemsWhereStorefront, setItemAmount } from "./repositories/Store/InventoryRepository.js";
 import { InventoryItem } from "./schemas/storeFrontSchema.js";
 import { createLedger } from "./repositories/Store/InventoryLedgerRepository.js";
@@ -194,8 +194,14 @@ async function startServer() {
       return res.status(401).send();
     }
 
-    const ok = await authenticateReader(SN, Key);
+    const reader = await getReaderBySN(SN);
+    if (reader == null){
+      return res.status(404).send();
+    }
+
+    const ok = await authenticateReader(reader, Key);
     if (!ok) {
+      wsApiLog("Declining API file to unauthed shlug with SN " + SN, "file");
       return res.status(403).send();
     }
     return next();
@@ -208,6 +214,29 @@ async function startServer() {
       return res.status(404).send();
     }
     return res.send(certca);
+  })
+
+  app.get('/api/files/ota/:tagname', async function (req, res) {
+    const tag = req.params["tagname"];
+    console.log(`SN: ${req.headers['shlug-sn']} requested OTA to ${tag}`);
+    
+    const ota_url = `https://github.com/rit-construct-makerspace/access-control-firmware/releases/download/${tag}/Core.bin`
+    fetch(ota_url).then(actual => {
+      actual.headers.forEach((v, n) => res.setHeader(n, v));
+      if (actual?.body) {
+        actual.body.pipeTo(
+          new WritableStream({
+            start() { },
+            write(chunk) {
+              res.write(chunk);
+            },
+            close() {
+              res.end();
+            },
+          })
+        );
+      }
+    })
   })
 
   /**
@@ -874,14 +903,14 @@ async function startServer() {
     }
   });
 
-    /**
-   * SET--
-   * Set the count of a declared item to a specified amount
-   * Request (JSON Body):
-   * - UID: NFC ID of the user 
-   * - Count: Number to set as the count. Cannot be negative.
-   * - Key: API key for authorization.
-   */
+  /**
+ * SET--
+ * Set the count of a declared item to a specified amount
+ * Request (JSON Body):
+ * - UID: NFC ID of the user 
+ * - Count: Number to set as the count. Cannot be negative.
+ * - Key: API key for authorization.
+ */
   app.post("/api/inv/set/:id", async function (req, res) {
     try {
       const id = parseInt(req.params.id);

--- a/server/src/wsapi.ts
+++ b/server/src/wsapi.ts
@@ -20,9 +20,16 @@ import { getZoneByID, hasZoneTrainings } from "./repositories/Zones/ZonesResposi
 
 
 const API_NORMAL_LOGGING = process.env.API_NORMAL_LOGGING == "true";
-const API_DEBUG_LOGGING = process.env.API_DEBUG_LOGGING == "true";
 
 const MIN_SESSION_LENGTH = 15
+
+
+enum WSAPIError {
+  Protocol = 4000,
+  InvalidMessageFormat = 4001,
+  Unauthenticated = 4002,
+  BadBootMessage = 4003,
+}
 
 /**
  * Pool of active shlugs to send info to
@@ -79,6 +86,28 @@ export async function identifyReader(executingUser: UserRow, readerId: number, d
   return true;
 }
 
+
+export async function requestOTA(executingUser: UserRow, readerIds: number[], otaTag: string): Promise<{ id: number, ret: string }[]> {
+  const url = `https://github.com/rit-construct-makerspace/access-control-firmware/releases/tag/${otaTag}`;
+  await fetch(url).then(res => {
+    if (res.status != 200) {
+      return "no such release";
+    }
+  });
+  async function requestOTAToOne(id: number): Promise<{ id: number, ret: string }> {
+    const connData = slugPool.get(id);
+    if (connData == null) {
+      return { id: id, ret: "no such reader" };
+    }
+    sendToShlugUnprompted(connData, { "OTATag": otaTag });
+    return { id: id, ret: "sent" }
+  }
+  return await Promise.all(
+    readerIds.map(requestOTAToOne)
+  );;
+}
+
+
 /**
  * Sends a state to a shlug
  * @param readerId reader to send the state to
@@ -115,7 +144,6 @@ export async function sendState(executingUser: UserRow, readerId: number, state:
       { id: executingUser.id, label: getUsersFullName(executingUser) },
       equipmentLabel
     );
-
   }
 
   sendToShlugUnprompted(connData, { "State": state });
@@ -502,13 +530,75 @@ async function authorizeUidToStateChange(uid: string, toState: string, readerId:
   }
 }
 
+async function lookupMostRecentGitTagForTrack(trackname: string): Promise<string> {
+  const github_api_url = 'https://api.github.com/repos/rit-construct-makerspace/access-control-firmware/releases';
+  var tag = "";
+
+  try {
+    interface Version {
+      tagname: string,
+      name: string,
+      published_at: Date,
+    };
+    await fetch(github_api_url).then(async resp => {
+      if (resp.body == null) { return; }
+      const res: any[] = await resp.json();
+
+      var releases: Version[] = res.map(r => { return { tagname: r.tag_name as string, name: r.name as string, published_at: new Date(r.published_at) } });
+      releases.sort((a, b) => (b.published_at.getTime() - a.published_at.getTime()))
+      const release = releases.filter(v => v.name.startsWith(trackname))[0];
+      if (release) {
+        tag = release.tagname;
+      } else {
+        console.error(`Failed to find matching release for '${trackname}' track OTA`)
+      }
+    })
+  } catch (e) {
+    console.error("Failed to query github api for OTA version: ", e);
+    return "";
+
+  }
+  return tag;
+}
+
+export async function getAvailableFirmwareTags(): Promise<string[]> {
+  const github_api_url = 'https://api.github.com/repos/rit-construct-makerspace/access-control-firmware/releases';
+
+  return await fetch(github_api_url).then(async resp => {
+    if (resp.body == null) { return []; }
+    const res: any[] = await resp.json();
+    return res.map(o => o.tag_name)
+  })
+}
+
+async function lookupGitTagForShlug(reader: ReaderRow): Promise<string | null> {
+  const currentVer = reader.BEVer;
+  const track = reader.targetFirmwareVersion ?? "stable";
+
+  if (track == "no-ota") {
+    return "";
+  } else if (track == "stable") {
+    const tag = await lookupMostRecentGitTagForTrack(track);
+    if (tag == currentVer || tag == "") {
+      return null;
+    } else {
+      return tag;
+    }
+  }
+
+  // the track is just a github tag
+  return reader.targetFirmwareVersion ?? null;
+}
+
 /**
  * Finds and packages data requested by the shlug from the server
  * @param connData state of the connection
  * @param requested_values list of keys that the shlug is requesting from us
  * @returns response containing those keys
  */
-async function handleRequest(connData: ConnectionData | undefined, requested_values: string[]): Promise<ShlugResponse> {
+async function handleRequest(connData: ConnectionData | undefined, requested_values: string[], currentFWVersion: string): Promise<ShlugResponse> {
+  const reader: ReaderRow | undefined = await getReaderByID(connData?.readerId ?? 0);
+
   var obj: ShlugResponse = { Seq: -1 };
   for (let value of requested_values) {
     switch (value) {
@@ -516,7 +606,6 @@ async function handleRequest(connData: ConnectionData | undefined, requested_val
         obj.Time = Math.floor(Date.now() / 1000);
         break;
       case "State":
-        const reader: ReaderRow | undefined = await getReaderByID(connData?.readerId ?? 0);
         if (reader?.id == null) {
           wsApiLog(`Couldn't find requested reader information for id ${connData?.readerId}. Telling Idle`, "State")
           obj.State = "Idle";
@@ -534,8 +623,17 @@ async function handleRequest(connData: ConnectionData | undefined, requested_val
           }
         }
         break;
+      case "OTATag":
+        if (reader == null) {
+          break;
+        }
+        const gittag: string | null = await lookupGitTagForShlug(reader);
+        if (gittag && gittag != currentFWVersion) {
+          obj.OTATag = gittag;
+        }
+        break;
       default:
-        wsApiLog(`Invalid request from Shlug ${connData?.readerId}`, "ACS Message")
+        console.error(`Invalid request from Shlug ${connData?.readerId}:`, value);
     }
   }
   return obj;
@@ -546,6 +644,8 @@ interface ShlugMessage {
   SerialNumber?: string
 
   FWVersion?: string;
+  FEVer?: string;
+  BEVer?: string;
   HWVersion?: string;
   HWType?: string;
   Request?: string[];
@@ -565,6 +665,7 @@ interface ShlugMessage {
 // What the server sends to the shlug in response to a ShlugMessage
 interface ShlugResponse {
   Seq: number
+  Connected?: boolean
   Auth?: string
   AuthTo?: string
   Verified?: number
@@ -574,6 +675,7 @@ interface ShlugResponse {
 
   Time?: number /// unix timestamp
   State?: string
+  OTATag?: string // git tag
 }
 
 /**
@@ -619,21 +721,20 @@ async function generateUniqueHumanName() {
 
 /**
  * Checks if a shlug is valid, paired, and authenticated
- * @param readerSN SN reported by a client
- * @param readerKey Key associated with that SN that a client gave
+ * @param reader the machine that is trying to authenticate
+ * @param submittedKey Key associated with that SN that a client gave
  * @returns true if that is a valid, paired shlug
  */
-export async function authenticateReader(readerSN: string, readerKey: string): Promise<boolean> {
-  if (!readerSN || !readerKey) {
+export async function authenticateReader(reader: ReaderRow, submittedKey: string): Promise<boolean> {
+  if (!reader || !submittedKey) {
     return false;
   }
-  var reader: ReaderRow | undefined = await getReaderBySN(readerSN);
   if (reader?.pairTime == null || reader?.SN == null || reader?.readerKeyCycle == null) {
     return false;
 
   }
   const keyToMatch = await generateShlugKey(reader.pairTime, reader.SN, reader.readerKeyCycle);
-  if (readerKey != keyToMatch) {
+  if (submittedKey != keyToMatch) {
     return false;
   }
   return true;
@@ -648,13 +749,14 @@ export async function authenticateReader(readerSN: string, readerKey: string): P
  * @returns true on successful parse. False if missing fields or otherwise invalid
  */
 async function handleBootupMessage(connData: ConnectionData, message: ShlugMessage, ws: ws.WebSocket, srcIp: string): Promise<boolean> {
-  if (message.SerialNumber == null || message.Key == null || message.FWVersion == null || message.HWVersion == null || message.HWType == null) {
+  const hasSWVersions = (message.FWVersion != null) || (message.FEVer != null && message.BEVer != null);
+  if (message.SerialNumber == null || message.Key == null || !hasSWVersions || message.HWVersion == null || message.HWType == null) {
     if (message.Key) {
       message.Key = "<sanitized>";
     }
     console.error(`WSACS: Missing fields in boot message from ${srcIp}. Got ${JSON.stringify(message)}`);
     submitReaderLog(null, new Date(), { "WsEvent": "bad boot msg", "BadBootMsgReason": "missing fields", "ReaderIP": srcIp, "message": message });
-    ws.close(4000, "Invalid Fields");
+    ws.close(WSAPIError.InvalidMessageFormat, "Invalid Fields");
     return false;
   }
   var reader: ReaderRow | undefined = await getReaderBySN(message.SerialNumber ?? "");
@@ -662,17 +764,17 @@ async function handleBootupMessage(connData: ConnectionData, message: ShlugMessa
     wsApiLog(`WSACS: Request from unpaired shlug ${srcIp} (SN: ${reader?.SN}). Denying`, "status");
     console.error(`WSACS: Request from unpaired shlug ${srcIp}. Denying`);
     submitReaderLog(null, new Date(), { "WsEvent": "bad boot msg", "BadBootMsgReason": "unpaired", "ReaderIP": srcIp, "ReaderSN": reader?.SN, "message": message });
-    ws.close(4001, "Unpaired Reader. Rejected");
+    ws.close(WSAPIError.Protocol, "Unpaired Reader. Rejected");
     return false;
 
   }
-  const keyToMatch = await generateShlugKey(reader?.pairTime, reader?.SN, reader?.readerKeyCycle);
-  if (message.Key != keyToMatch) {
+
+  if (!authenticateReader(reader, message.Key)) {
     wsApiLog(`WSACS: Invalid key from SN ${reader?.SN} on connect. Was it paired correctly?`, "status");
     message.Key = "<sanitized>";
     await submitReaderLog(null, new Date(), { "WsEvent": "bad boot msg", "BadBootMsgReason": "wrong key", "ReaderIP": srcIp, "ReaderSN": reader?.SN, "message": message });
     console.error(`WSACS: Invalid key from SN ${reader?.SN} on connect.`);
-    ws.close(4002, "Invalid Key. Rejected")
+    ws.close(WSAPIError.Unauthenticated, "Invalid Key. Rejected")
     return false;
   }
 
@@ -732,8 +834,8 @@ async function handleBootupMessage(connData: ConnectionData, message: ShlugMessa
     lastStatusReason: reader.lastStatusReason,
     scheduledStatusFreq: reader.scheduledStatusFreq,
     helpRequested: reader.helpRequested,
-    BEVer: message.FWVersion ?? undefined,
-    FEVer: message.FWVersion ?? undefined,
+    BEVer: message.BEVer ?? message.FWVersion ?? undefined,
+    FEVer: message.FEVer ?? message.FWVersion ?? undefined,
     HWVer: message.HWVersion ?? undefined,
     SN: message.SerialNumber,
   });
@@ -747,7 +849,7 @@ async function handleBootupMessage(connData: ConnectionData, message: ShlugMessa
  * @param newState the state the shlug changed to
  * @param activeUID the active UID if there is one. null if no card inserted
  */
-async function handleStateTransition(reader: ReaderRow, newState: string, activeUID: string | undefined, temp: number | undefined) {
+async function handleStateUpdateMessage(reader: ReaderRow, newState: string, activeUID: string | undefined, temp: number | undefined, nextAppVersion: string | undefined) {
   const timeOfChange: Date = new Date();
   const oldState = reader.state;
   const oldUID = reader.currentUID;
@@ -805,6 +907,7 @@ async function handleStateTransition(reader: ReaderRow, newState: string, active
     reader.recentSessionLength = elapsedSeconds;
   }
   reader.temp = temp ?? reader.temp;
+  reader.FEVer = nextAppVersion ?? reader.FEVer;
   await updateReaderStatus(reader);
 
 }
@@ -815,7 +918,7 @@ async function handleStateTransition(reader: ReaderRow, newState: string, active
  * @returns true if we should send this message to the reader
  */
 function isReplyWorthSending(resp: ShlugResponse): boolean {
-  if (resp.Verified || resp.Auth || resp.Error || resp.Reason || resp.Role || resp.State || resp.Time) {
+  if (resp.Verified || resp.Auth || resp.Error || resp.Reason || resp.Role || resp.State || resp.Time || resp.Connected) {
     return true
   }
   return false
@@ -865,7 +968,7 @@ export async function ws_acs_api(ws: ws.WebSocket, req: Request) {
 
       await submitReaderLog(connData.readerId ?? null, new Date(), { "WsEvent": "error", "WsErrorMsg": ev.message });
       console.error(`WSACS: websocket error ${ev.error} - ${ev.type}: ${ev.message}`)
-      ws.close(4000, "got unrecoverable error");
+      ws.close(WSAPIError.Protocol, "got unrecoverable error");
     }
 
     ws.onmessage = async function (ev: ws.MessageEvent) {
@@ -875,7 +978,7 @@ export async function ws_acs_api(ws: ws.WebSocket, req: Request) {
           console.error(`Invalid Shlug Message: ${JSON.stringify(ev.data)}. Forcing reconnect`);
           await submitReaderLog(connData.readerId ?? null, new Date(), { "WsEvent": "invalid message", "Data": ev.data });
 
-          ws.close(4001, "Invalid Message");
+          ws.close(WSAPIError.InvalidMessageFormat, "Invalid Message");
           return;
         }
 
@@ -885,12 +988,14 @@ export async function ws_acs_api(ws: ws.WebSocket, req: Request) {
           if (!await handleBootupMessage(connData, shlugMessage, ws, req.ip ?? "unknown ip")) {
             // failed to setup  
             console.error("WSACS: Incorrect Boot Message. Forcing Reconnect")
-            ws.close(4001, "Invalid Boot Message");
+            ws.close(WSAPIError.BadBootMessage, "Invalid Boot Message");
+
             return;
           }
         }
         if (connData.readerId == null) {
-          wsApiLog("Can not process WSAPI message. Null reader ID (this shouldn't happen): " + ev.data, "status")
+          wsApiLog("Can not process WSAPI message -> forcing disconnect. Null reader ID: " + ev.data, "status")
+          ws.close(WSAPIError.Protocol, "Server couldnt process due to null reader id");
           return;
         }
 
@@ -901,11 +1006,14 @@ export async function ws_acs_api(ws: ws.WebSocket, req: Request) {
           submitReaderLog(null, new Date(), { "WsEvent": "undefined reader", "ReaderIP": req.ip, "ReaderID": connData?.readerId });
           console.error(`Failed to find entry for device. Forcing Reconnect. ID: ${connData.readerId}, Last State: ${connData.currentState}. IP: ${req.ip}: ${JSON.stringify(shlugMessage)}`);
           // Closing the websocket will make it reauth and hopefully tell us its id
-          ws.close(4000, "No Device Found");
+          ws.close(WSAPIError.Protocol, "No Device Found");
           return;
         }
-        var response: ShlugResponse = await handleRequest(connData, shlugMessage.Request || [])
-
+        var response: ShlugResponse = await handleRequest(connData, shlugMessage.Request || [], reader.BEVer);
+        if (shlugMessage.Seq == 0) {
+          // always send a response back on connect
+          response.Connected = true;
+        }
         if (shlugMessage.Message) {
           try {
             const instance = await getInstanceByReaderID(reader.id);
@@ -926,7 +1034,7 @@ export async function ws_acs_api(ws: ws.WebSocket, req: Request) {
           }
         }
         if (shlugMessage.State) {
-          await handleStateTransition(reader, shlugMessage.State, shlugMessage.UID, shlugMessage?.Temp)
+          await handleStateUpdateMessage(reader, shlugMessage.State, shlugMessage.UID, shlugMessage?.Temp, shlugMessage?.FEVer)
         }
 
         if (shlugMessage.Auth && (shlugMessage.AuthTo == null || shlugMessage.AuthTo == "Unlocked")) {


### PR DESCRIPTION
- Update WSAPI handler to support OTATag requests and responses. 
- Add passthrough endpoint /api/files/ota/<tagname> to download firmware through make
- Revamp Reader Page and Card
  - New UI completely
  - OTA Target Version Control
  - Searching now takes into account paired machine and makerspace name