### PR TITLE
Allow searching by number and text in CurrencyLedger + Performance improvements

### DIFF
--- a/client/src/pages/lab_management/currency/CurrencyLedger.tsx
+++ b/client/src/pages/lab_management/currency/CurrencyLedger.tsx
@@ -92,63 +92,62 @@ export default function CurrencyLedger() {
     second: "2-digit",
   });
 
+  function renderTransactionButton(transactionEntryId: number | null) {
+    if (transactionEntryId == null) {
+      return null
+    }
+    return <Button
+      variant="contained"
+      endIcon={<VisibilityIcon />}
+      onClick={() => { alert(`View teid: ${transactionEntryId}`) }}
+    >
+      View Transaction
+    </Button>
+  }
+
+  const columns: GridColDef[] = [
+    { field: "id", headerName: "ID", width: 100 },
+    { field: "accountID", headerName: "Account ID", width: 100 },
+    { field: "owner", headerName: "Account Owner", width: 150 },
+    { field: "currencyType", headerName: "Type", width: 150 },
+    { field: "amount", headerName: "Amount", width: 120 },
+    { field: "dateTime", headerName: "Date", width: 200 },
+    { field: "transactionEntryId", headerName: "Transaction", width: 250, renderCell: (params) => renderTransactionButton(params.row.transactionEntryId) },
+    { field: "description", headerName: "Description", width: 500 },
+    { field: "atxID", headerName: "ATX ID", width: 120 },
+    { field: "refID", headerName: "REF ID", width: 120 },
+  ];
   return (
-    <RequestWrapper2 result={ledgerEntriesResults} render={(data) => {
+    <Stack spacing={2}>
+      <SearchBar
+        placeholder="Search Ledger"
+        sx={{ maxWidth: 300 }}
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
+        onClear={() => setUrlParam("l", "")}
+        onSubmit={() => setUrlParam("l", searchText)}
+      />
+      <RequestWrapper2 result={ledgerEntriesResults} render={(data) => {
 
-      const entries: CurrencyLedgerEntry[] = data.currencyLedgerEntriesLimit;
+        const entries: CurrencyLedgerEntry[] = data.currencyLedgerEntriesLimit;
 
-      function renderTransactionButton(transactionEntryId: number | null) {
-        if (transactionEntryId == null) {
-          return null
-        }
-        return <Button
-          variant="contained"
-          endIcon={<VisibilityIcon />}
-          onClick={() => { alert(`View teid: ${transactionEntryId}`) }}
-        >
-          View Transaction
-        </Button>
+        const rows: GridRowsProp = entries.map((entry) => ({
+          id: entry.id,
+          accountID: entry.accountID,
+          owner: entry.owner,
+          currencyType: entry.currencyType,
+          amount: moneyFormatter.format(entry.amount / 100),
+          dateTime: dateTimeFormatter.format(new Date(entry.dateTime)),
+          transactionEntryId: entry.transactionEntryId,
+          description: entry.description,
+          atxID: entry.atxID,
+          refID: entry.refID,
+        }))
 
-      }
-      const columns: GridColDef[] = [
-        { field: "id", headerName: "ID", width: 100 },
-        { field: "accountID", headerName: "Account ID", width: 100 },
-        { field: "owner", headerName: "Account Owner", width: 150 },
-        { field: "currencyType", headerName: "Type", width: 150 },
-        { field: "amount", headerName: "Amount", width: 120 },
-        { field: "dateTime", headerName: "Date", width: 200 },
-        { field: "transactionEntryId", headerName: "Transaction", width: 250, renderCell: (params) => renderTransactionButton(params.row.transactionEntryId) },
-        { field: "description", headerName: "Description", width: 500 },
-        { field: "atxID", headerName: "ATX ID", width: 120 },
-        { field: "refID", headerName: "REF ID", width: 120 },
-      ];
-
-      const rows: GridRowsProp = entries.map((entry) => ({
-        id: entry.id,
-        accountID: entry.accountID,
-        owner: entry.owner,
-        currencyType: entry.currencyType,
-        amount: moneyFormatter.format(entry.amount / 100),
-        dateTime: dateTimeFormatter.format(new Date(entry.dateTime)),
-        transactionEntryId: entry.transactionEntryId,
-        description: entry.description,
-        atxID: entry.atxID,
-        refID: entry.refID,
-      }))
-
-      return (
-        <Stack spacing={2}>
-          <SearchBar
-            placeholder="Search Ledger"
-            sx={{ maxWidth: 300 }}
-            value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
-            onClear={() => setUrlParam("l", "")}
-            onSubmit={() => setUrlParam("l", searchText)}
-          />
+        return (
           <DataGrid rows={rows} columns={columns} slots={{ columnMenu: CustomColumnMenu }} />
-        </Stack>
-      );
-    }} />
+        );
+      }} />
+    </Stack>
   );
 }

--- a/server/src/repositories/Currency/CurrencyLedgerRepository.ts
+++ b/server/src/repositories/Currency/CurrencyLedgerRepository.ts
@@ -70,20 +70,23 @@ export async function getCurrencyLedgerEntriesLimit(searchText?: string, limit =
 
     if (Number.isNaN(Number(searchText))) {
         // searchText can't be compared to the number fields
-        return await knex("CurrencyLedger").select("*").orderBy("dateTime", "desc")
+        return await knex("CurrencyLedger").select("*")
             .whereILike("description", `%${searchText}%`)
             .orWhereILike("currencyType", `%${searchText}%`)
             .orWhereILike("owner", `%${searchText}%`)
-            .limit(limit);
+            .orderBy("dateTime", "desc").limit(limit);
     }
 
-    return await knex("CurrencyLedger").select("*").orderBy("dateTime", "desc")
+    return await knex("CurrencyLedger").select("*")
         .where("id", searchText)
         .orWhere("accountID", searchText)
         .orWhere("amount", searchText)
         .orWhere("atxID", searchText)
         .orWhere("refID", searchText)
-        .limit(limit);
+        .orWhereILike("description", `%${searchText}%`)
+        .orWhereILike("currencyType", `%${searchText}%`)
+        .orWhereILike("owner", `%${searchText}%`)
+        .orderBy("dateTime", "desc").limit(limit);
 }
 
 export async function getCurrencyLedgerEntry(id: number): Promise<CurrencyLedgerRow> {


### PR DESCRIPTION
made it so you can search text fields like username (idk1234) or description (job id 45) by number without it assuming you are searching only number fields

Also, rearrange page so that typing doesnt trigger RequestWrapper callback to rerender entire datagrid so typing is a bit snappier